### PR TITLE
Fix prime factorization import for Python 3

### DIFF
--- a/Python/Prime Factorization/prime_factorization.py
+++ b/Python/Prime Factorization/prime_factorization.py
@@ -7,7 +7,7 @@ Prime Factorization –
 import sys
 import timeit
 from random import randint
-from fractions import gcd
+from math import gcd
 
 POLLARD_S = 5
 


### PR DESCRIPTION
## Summary
- update `prime_factorization.py` to use `math.gcd`

## Testing
- `python Python/'Prime Factorization'/prime_factorization.py`

------
https://chatgpt.com/codex/tasks/task_b_68713a5af8c8832cbb982bfa21ca3adc