### PR TITLE
Fix typo in prime factorization script

### DIFF
--- a/Python/Prime Factorization/prime_factorization.py
+++ b/Python/Prime Factorization/prime_factorization.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         print("A number should be an integer")
         sys.exit(0)
     if number < 1:
-        print("A number should be great than 1")
+        print("A number should be greater than 1")
         sys.exit(0)
     print("Results:")
     for method in METHODS:


### PR DESCRIPTION
## Summary
- correct a typo in the prime factorization script

## Testing
- `python3 -m py_compile Python/Prime\ Factorization/prime_factorization.py`


------
https://chatgpt.com/codex/tasks/task_b_68713ce91c58832cafbde59f2bbc2e0b