### PR TITLE
Fix prime factorization tests

### DIFF
--- a/JavaScript/Prime Factorization/tests.js
+++ b/JavaScript/Prime Factorization/tests.js
@@ -11,8 +11,8 @@ exports.testSimple = function(test) {
 exports.testEmpty = function (test) {
     test.expect(3);
     test.deepEqual(primeFactors(1), [], "1");
-    test.deepEqual(primeFactors(1), [], "0");
-    test.deepEqual(primeFactors(1), [], "-2");
+    test.deepEqual(primeFactors(0), [], "0");
+    test.deepEqual(primeFactors(-2), [], "-2");
     test.done();
 };
 


### PR DESCRIPTION
## Summary
- fix empty input cases in prime factorization tests

## Testing
- `node JavaScript/'Find PI to the Nth Digit'/tests.js`
- `node - <<'EOF'
const primeFactors = require('./JavaScript/Prime Factorization/prime_factorization');
const assert = require('assert');
assert.deepStrictEqual(primeFactors(6), [2,3]);
assert.deepStrictEqual(primeFactors(7), [7]);
assert.deepStrictEqual(primeFactors(16), [2,2,2,2]);
assert.deepStrictEqual(primeFactors(1), []);
assert.deepStrictEqual(primeFactors(0), []);
assert.deepStrictEqual(primeFactors(-2), []);
assert.deepStrictEqual(primeFactors(7919), [7919]);
assert.deepStrictEqual(primeFactors(104729), [104729]);
assert.deepStrictEqual(primeFactors(2), [2]);
EOF
`

------
https://chatgpt.com/codex/tasks/task_b_68713cec8e10832ca35a3ee861ec376a